### PR TITLE
Support typing profile in command line argument directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ alias awsp="source _awsp"
 ```sh
 awsp
 ```
+or
+```
+awsp default
+```
+
 
 ## Show your AWS Profile in your shell prompt
 For better visibility into what your shell is set to it's helpful to configure your prompt to show the value of the env variable `AWS_PROFILE`.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const inquirer = require('inquirer');
+const chalk = require('chalk');
 
 console.log('AWS Profile Switcher');
 
@@ -27,17 +28,22 @@ const promptProfileChoice = (data) => {
 
   profiles.push(defaultProfileChoice);
 
-  const profileChoice = [
-    {
-      type: 'list',
-      name: 'profile',
-      message: 'Choose a profile',
-      choices: profiles,
-      default: process.env.AWS_PROFILE || defaultProfileChoice
-    }
-  ];
+  if (process.argv[2]) {
+    console.log(`${chalk.bold('Choose a profile')} ${chalk.cyan(process.argv[2])}`);
+    return { 'profile': process.argv[2] };
+  } else {
+    const profileChoice = [
+      {
+        type: 'list',
+        name: 'profile',
+        message: 'Choose a profile',
+        choices: profiles,
+        default: process.env.AWS_PROFILE || defaultProfileChoice
+      }
+    ];
 
-  return inquirer.prompt(profileChoice);
+    return inquirer.prompt(profileChoice);
+  }
 }
 
 const readAwsProfiles = () => {


### PR DESCRIPTION
Add a feature for typing profile in command line argument directly. This can make profile changing on CI/CD server more flexible.